### PR TITLE
Pull request from branch-d2810c5b-4fed-41a5-aeed-6dd715b07ea2 to initial-use-of-line-number

### DIFF
--- a/tiller_python_service/controller.py
+++ b/tiller_python_service/controller.py
@@ -86,7 +86,7 @@ def ai_magic(comment_body, full_codebase_to_modify, **kwargs) -> str:
         )
         print(chat_completion)
         for response in chat_completion.choices:
-            msg = response.message.content.replace("```", "")
+            msg = response.message.content.replace("", "")
             if is_valid_python(msg):
                 response = msg
                 print(f"response: {msg}")
@@ -111,8 +111,7 @@ def _construct_prompt(comment_body, code_base, **kwargs):
         f" for the recommended adjustments - no other text, generated commentary, or unnecessary punctuation should be present. "
         f"This should continue to be valid Python code, and should not add unnecessary newlines.\n"
         f"Be sure to scan the surrounding context in order to make a thorough and reasonable change to the codebase."
-        f"Do not include the comment at the top of the return message." \
-        f" For example, a recommended change to functionality may entail a change to the function signature. \n"
+        f"Do not include the comment at the top of the return message. For example, a recommended change to functionality may entail a change to the function signature. "
     )
 
     prompt += "You: "


### PR DESCRIPTION
b'diff --git a/tiller_python_service/controller.py b/tiller_python_service/controller.py\nindex 9fd65f8..1aab8e2 100644\n--- a/tiller_python_service/controller.py\n+++ b/tiller_python_service/controller.py\n@@ -86,7 +86,7 @@ def ai_magic(comment_body, full_codebase_to_modify, **kwargs) -> str:\n         )\n         print(chat_completion)\n         for response in chat_completion.choices:\n-            msg = response.message.content.replace("```", "")\n+            msg = response.message.content.replace("", "")\n             if is_valid_python(msg):\n                 response = msg\n                 print(f"response: {msg}")\n@@ -111,8 +111,7 @@ def _construct_prompt(comment_body, code_base, **kwargs):\n         f" for the recommended adjustments - no other text, generated commentary, or unnecessary punctuation should be present. "\n         f"This should continue to be valid Python code, and should not add unnecessary newlines.\\n"\n         f"Be sure to scan the surrounding context in order to make a thorough and reasonable change to the codebase."\n-        f"Do not include the comment at the top of the return message." \\\n-        f" For example, a recommended change to functionality may entail a change to the function signature. \\n"\n+        f"Do not include the comment at the top of the return message. For example, a recommended change to functionality may entail a change to the function signature. "\n     )\n \n     prompt += "You: "\n'